### PR TITLE
Initial widget setup and its toggle logic

### DIFF
--- a/packages/app/src/components/Button.tsx
+++ b/packages/app/src/components/Button.tsx
@@ -1,10 +1,10 @@
-import nook from "nook"
+import nook from "nook";
 import { Button as RSButton } from "reshaped";
 import Logo from "./Logo";
 
 const Button = (props: any) => {
   return (
-    <RSButton {...props}>
+    <RSButton {...props} onClick={() => console.log("11111")}>
       {props.children}
       <br />
       <br />

--- a/packages/nook/package.json
+++ b/packages/nook/package.json
@@ -9,7 +9,7 @@
     "watch:css": "chokidar \"src/**/*.css\" -c \"yarn build:css\" --initial true",
     "build:js": "tsc",
     "watch:js": "tsc -w",
-    "build": "tsc && rsync -a src/* dist/ --exclude='*.tsx' --exclude='*.ts'",
+    "build": "yarn build:css && yarn build:js",
     "dev": "concurrently \"yarn watch:css\" \"yarn watch:js\""
   },
   "peerDependencies": {

--- a/packages/nook/src/components/InspectedComponent/InspectedComponent.module.css
+++ b/packages/nook/src/components/InspectedComponent/InspectedComponent.module.css
@@ -7,8 +7,8 @@
 
   box-shadow: 0 0 0 3px var(--nook-selection-color) inset;
   position: absolute;
-  pointer-events: none;
   border-radius: 4px;
+  pointer-events: none;
 }
 
 .name {

--- a/packages/nook/src/components/NookProvider/NookProvider.tsx
+++ b/packages/nook/src/components/NookProvider/NookProvider.tsx
@@ -12,6 +12,7 @@ export const useNook = () => React.useContext(Context);
 
 export const NookProvider = (props: T.Props) => {
   const { children } = props;
+  const [mode, setMode] = React.useState<T.Mode>("idle");
   const [components, setComponents] = React.useState<T.Context["components"]>(
     {},
   );
@@ -30,7 +31,9 @@ export const NookProvider = (props: T.Props) => {
   }, []);
 
   return (
-    <Context.Provider value={{ components, register, unregister }}>
+    <Context.Provider
+      value={{ components, register, unregister, mode, setMode }}
+    >
       {children}
       <Widget />
     </Context.Provider>

--- a/packages/nook/src/components/NookProvider/NookProvider.types.ts
+++ b/packages/nook/src/components/NookProvider/NookProvider.types.ts
@@ -1,5 +1,7 @@
 import React from "react";
 
+export type Mode = "idle" | "inspect" | "active";
+
 export type Props = {
   children: React.ReactNode;
 };
@@ -9,4 +11,6 @@ export type Context = {
   components: Record<string, ComponentData>;
   register: (id: string, data: ComponentData) => void;
   unregister: (id: string) => void;
+  mode: Mode;
+  setMode: React.Dispatch<React.SetStateAction<Mode>>;
 };

--- a/packages/nook/src/components/Widget/Widget.module.css
+++ b/packages/nook/src/components/Widget/Widget.module.css
@@ -2,5 +2,15 @@
   position: fixed;
   inset-block-end: var(--rs-unit-x2);
   inset-inline-start: var(--rs-unit-x2);
-  width: 200px;
+  width: 260px;
+  height: 40px;
+  transition: var(--rs-duration-medium) var(--rs-easing-decelerate);
+  transition-property: width, height, inset;
+}
+
+.--active {
+  width: 600px;
+  height: 240px;
+  inset-block-end: var(--rs-unit-x4);
+  inset-inline-start: var(--rs-unit-x4);
 }

--- a/packages/nook/src/components/Widget/Widget.module.css
+++ b/packages/nook/src/components/Widget/Widget.module.css
@@ -1,7 +1,4 @@
 .root {
-  position: fixed;
-  inset-block-end: var(--rs-unit-x2);
-  inset-inline-start: var(--rs-unit-x2);
   width: 260px;
   height: 40px;
   transition: var(--rs-duration-medium) var(--rs-easing-decelerate);
@@ -11,6 +8,4 @@
 .--active {
   width: 600px;
   height: 240px;
-  inset-block-end: var(--rs-unit-x4);
-  inset-inline-start: var(--rs-unit-x4);
 }

--- a/packages/nook/src/components/Widget/Widget.tsx
+++ b/packages/nook/src/components/Widget/Widget.tsx
@@ -1,30 +1,38 @@
 "use client";
 
-import s from "./Widget.module.css";
+import React from "react";
 import {
   View,
   Text,
   Badge,
   Actionable,
   Icon,
+  Tooltip,
   useToggle,
   useHotkeys,
   classNames,
 } from "reshaped";
 import { useNook } from "../NookProvider";
 import IconCrosshair from "../../icons/Crosshair";
+import s from "./Widget.module.css";
 
 const Widget = () => {
   const nook = useNook();
-  const activeToggle = useToggle();
-  const rootClassNames = classNames(
-    s.root,
-    activeToggle.active && s["--active"],
-  );
+  const active = nook.mode === "active";
+  const rootClassNames = classNames(s.root, active && s["--active"]);
 
-  useHotkeys({
-    "meta+i": activeToggle.toggle,
-  });
+  const handleInspectClick = React.useCallback(() => {
+    nook.setMode((prev) => {
+      return prev === "inspect" ? "idle" : "inspect";
+    });
+  }, [nook]);
+
+  useHotkeys(
+    {
+      "meta+i": handleInspectClick,
+    },
+    [handleInspectClick],
+  );
 
   return (
     <View
@@ -33,6 +41,8 @@ const Widget = () => {
       borderRadius="medium"
       position="fixed"
       className={rootClassNames}
+      insetStart={active ? 4 : 2}
+      insetBottom={active ? 4 : 2}
     >
       <View direction="row" gap={3} padding={2} align="center">
         <View.Item grow>
@@ -40,13 +50,17 @@ const Widget = () => {
             Nook
           </Text>
         </View.Item>
-        <Actionable onClick={activeToggle.toggle}>
-          <Icon
-            size={4}
-            svg={IconCrosshair}
-            color={activeToggle.active ? "primary" : "neutral"}
-          />
-        </Actionable>
+        <Tooltip text="⌘I" position="start">
+          {(attributes) => (
+            <Actionable onClick={handleInspectClick} attributes={attributes}>
+              <Icon
+                size={4}
+                svg={IconCrosshair}
+                color={nook.mode === "inspect" ? "primary" : "neutral"}
+              />
+            </Actionable>
+          )}
+        </Tooltip>
         <Badge>{Object.keys(nook.components).length} components</Badge>
       </View>
     </View>

--- a/packages/nook/src/components/Widget/Widget.tsx
+++ b/packages/nook/src/components/Widget/Widget.tsx
@@ -1,16 +1,56 @@
 "use client";
 
-import s from "./Widget.module.css"
-import { View, Text } from "reshaped"
+import s from "./Widget.module.css";
+import {
+  View,
+  Text,
+  Badge,
+  Actionable,
+  Icon,
+  useToggle,
+  useHotkeys,
+  classNames,
+} from "reshaped";
+import { useNook } from "../NookProvider";
+import IconCrosshair from "../../icons/Crosshair";
 
 const Widget = () => {
+  const nook = useNook();
+  const activeToggle = useToggle();
+  const rootClassNames = classNames(
+    s.root,
+    activeToggle.active && s["--active"],
+  );
+
+  useHotkeys({
+    "meta+i": activeToggle.toggle,
+  });
+
   return (
-    <div className={s.root}>
-      <View backgroundColor="elevation-overlay" borderRadius="medium" padding={2} paddingInline={3}>
-        <Text variant="caption-1" weight="medium">Nook</Text>
+    <View
+      backgroundColor="elevation-overlay"
+      borderColor="neutral-faded"
+      borderRadius="medium"
+      position="fixed"
+      className={rootClassNames}
+    >
+      <View direction="row" gap={3} padding={2} align="center">
+        <View.Item grow>
+          <Text variant="caption-1" weight="medium">
+            Nook
+          </Text>
+        </View.Item>
+        <Actionable onClick={activeToggle.toggle}>
+          <Icon
+            size={4}
+            svg={IconCrosshair}
+            color={activeToggle.active ? "primary" : "neutral"}
+          />
+        </Actionable>
+        <Badge>{Object.keys(nook.components).length} components</Badge>
       </View>
-    </div>
-  )
-}
+    </View>
+  );
+};
 
 export default Widget;

--- a/packages/nook/src/icons/Crosshair.tsx
+++ b/packages/nook/src/icons/Crosshair.tsx
@@ -6,9 +6,9 @@ const IconCrosshair = () => (
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
   >
     <circle cx="12" cy="12" r="10" />
     <line x1="22" y1="12" x2="18" y2="12" />

--- a/packages/nook/src/icons/Crosshair.tsx
+++ b/packages/nook/src/icons/Crosshair.tsx
@@ -1,0 +1,21 @@
+const IconCrosshair = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="22" y1="12" x2="18" y2="12" />
+    <line x1="6" y1="12" x2="2" y2="12" />
+    <line x1="12" y1="6" x2="12" y2="2" />
+    <line x1="12" y1="22" x2="12" y2="18" />
+  </svg>
+);
+
+export default IconCrosshair;


### PR DESCRIPTION
Adding the widget that handles 3 modes:
- idle is its default state
- inspect is the mode when user selects a component they want to inspect. It enables component highlighting on the page
- active is the mode when widget expands to show the information about the inspected component

While we're switching to inspect mode - all default component click handlers get disabled to avoid side effects the cause page navigation or components getting unmounted


https://github.com/formaat-design/nook/assets/887379/127edbab-698d-4589-b1b3-17273c6d7d62

Next PR will focus on saving the state for the selected component, to keep it highlighted on the page and display its component tree and props in the widget